### PR TITLE
Improve validation of Controlled Vocabulary terms in SHACL

### DIFF
--- a/ontologies/iptc-sport-shacl.ttl
+++ b/ontologies/iptc-sport-shacl.ttl
@@ -27,15 +27,11 @@ sport:ActionShape
   ] ;
   sh:property [
     sh:path sport:actionDateTime ;
-    sh:datatype xsd:string
-    # sh:datatype xsd:dateTime
+    sh:datatype xsd:dateTime
   ] ;
   sh:property [
     sh:path sport:actionType ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/sp" ;
-    sh:nodeKind sh:IRI ;
-    sh:flags   "i"  # Ignore case
+    sh:node sport:NewsCodesSportActionTypeShape
   ] ;
   sh:property [
     sh:path sport:angle ;
@@ -47,10 +43,8 @@ sport:ActionShape
   ] ;
   sh:property [
     sh:path sport:class ;
-    sh:nodeKind sh:IRI ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/spactionclass/" ;
-    sh:flags   "i"  # Ignore case
+    sh:class skos:Concept ;
+    sh:node sport:NewsCodesSportActionClassShape ;
   ] ;
   sh:property [
     sh:path sport:comment ;
@@ -255,7 +249,7 @@ sport:CompetitionShape
     sh:path sport:sport ;
     sh:class skos:Concept ;
     # sh:minCount 1 ; # removed for now because it breaks most of our examples!
-    sh:node sport:MediaTopicShape ;
+    sh:node sport:NewsCodesMediaTopicShape ;
   ] ;
   sh:property [
     sh:path sport:competitionType ;
@@ -292,7 +286,7 @@ sport:CompetitionPhaseShape
     sh:path sport:sport ;
     sh:class skos:Concept ;
     # sh:minCount 1 ; # removed for now because it breaks most of our examples!
-    sh:node sport:MediaTopicShape ;
+    sh:node sport:NewsCodesMediaTopicShape ;
   ] ;
   sh:property [
     sh:path sport:participation ;
@@ -301,9 +295,7 @@ sport:CompetitionPhaseShape
   sh:property [
     sh:path sport:competitionFormat ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/sptournamentform/" ;
-    sh:flags   "i"  # Ignore case
+    sh:node sport:NewsCodesSportCompetitionFormatShape
   ] ;
   sh:property [
     sh:path sport:parent ;
@@ -312,9 +304,7 @@ sport:CompetitionPhaseShape
   sh:property [
     sh:path sport:competitionPhaseType ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/sptournamentphase/" ;
-    sh:flags   "i"  # Ignore case
+    sh:node sport:NewsCodesSportCompetitionPhaseTypeShape
   ] ;
   sh:property [
     sh:path sport:phaseInCompetition ;
@@ -326,34 +316,20 @@ sport:CompetitorParticipationShape rdf:type sh:NodeShape  ;
   sh:targetClass sport:CompetitorParticipation ;
   sh:ignoredProperties ( rdf:type rdfs:label ) ;
   # properties inherited from sport:Participation
-  # TODO decide whether we have sport:eventOutcome or spstat:eventOutcome
   sh:property [
     sh:path sport:eventOutcome ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
-    sh:flags   "i"                                               # Ignore case
-  ] ;
-  sh:property [
-    sh:path spstat:eventOutcome ;
-    sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportEventOutcomeShape
   ] ;
   sh:property [
     sh:path sport:eventOutcomeType ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcometype/" ;
-    sh:flags   "i"  # Ignore case
+    sh:node sport:NewsCodesSportEventOutcomeTypeShape
   ] ;
   sh:property [
     sh:path sport:positionEvent ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|vendoffpos)/" ;
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportPositionShape
   ] ;
   #sh:property [
   #  sh:path sport:participationBy ;
@@ -378,9 +354,7 @@ sport:CompetitorParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:scoreUnits ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/spscoreunits/" ;  # term is from CV
-    sh:flags   "i"                                              # Ignore case
+    sh:node sport:NewsCodesSportScoreUnitsShape
   ] .
  
 sport:EventShape rdf:type sh:NodeShape ;
@@ -428,21 +402,15 @@ sport:EventShape rdf:type sh:NodeShape ;
     sh:path sport:sport ;
     sh:class skos:Concept ;
     # sh:minCount 1 ; # removed for now because it breaks most of our examples!
-    sh:node sport:MediaTopicShape ;
+    sh:node sport:NewsCodesMediaTopicShape ;
   ] ;
   sh:property [
     sh:path sport:eventOutcomeType ;
-    sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcometype/" ; # term is from CV
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportEventOutcomeTypeShape ;
   ] ;
   sh:property [
     sh:path sport:eventStatus ;
-    sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventstatus/" ;  # term is from CV
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportEventStatusShape ;
   ] ;
   sh:property [
     sh:path sport:parent ;
@@ -471,9 +439,7 @@ sport:IndividualMembershipShape
   sh:property [
     sh:path sport:positionRegular ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|sphorposition|spichposition)/" ;
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportPositionShape ;
   ] ;
   sh:property [
     sh:path sport:uniformNumber ;
@@ -501,47 +467,23 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:playerStatus ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/spplayerstatus/" ;
-    sh:flags   "i"  # Ignore case
-  ] ;
-  # properties defined on CompetitorParticipation
-  sh:property [
-    sh:path sport:playerStatus ;
-    sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/spplayerstatus/" ;
-    sh:flags   "i"  # Ignore case
+    sh:node sport:NewsCodesSportPlayerStatusShape
   ] ;
   # properties defined on Participation
-  # TODO decide whether we have sport:eventOutcome or spstat:eventOutcome
   sh:property [
     sh:path sport:eventOutcome ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
-    sh:flags   "i"                                               # Ignore case
-  ] ;
-  sh:property [
-    sh:path spstat:eventOutcome ;
-    sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportEventOutcomeShape
   ] ;
   sh:property [
     sh:path sport:eventOutcomeType ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcometype/" ;
-    sh:flags   "i"  # Ignore case
+    sh:node sport:NewsCodesSportEventOutcomeTypeShape
   ] ;
   sh:property [
     sh:path sport:positionEvent ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|vendoffpos)/" ;
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportPositionShape
   ] ;
   sh:property [
     sh:path sport:participationBy ;
@@ -566,9 +508,7 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:scoreUnits ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/spscoreunits/" ;  # term is from CV
-    sh:flags   "i"                                              # Ignore case
+    sh:node sport:NewsCodesSportScoreUnitsShape
   ] ;
   sh:property [
     sh:path sport:teamParticipation ;
@@ -585,10 +525,7 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
   ] ;
   sh:property [
     sh:path spstat:resultEffect ;
-    sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/spresulteffect/" ;
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportResultEffectShape
    ] ;
   sh:property [
     sh:path spstat:resultEffectTarget ;
@@ -798,13 +735,6 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
     sh:datatype xsd:string ;
   ] .
 
-sport:MediaTopicShape rdf:type sh:NodeShape;
-    sh:property [
-        sh:path skos:inScheme ;
-        sh:hasValue <http://cv.iptc.org/newscodes/mediatopic/> ;
-        sh:maxCount 1 ;
-    ] .
-
 sport:MembershipShape rdf:type sh:NodeShape  ;
   a sh:NodeShape ;
   sh:targetClass sport:Membership ;
@@ -821,6 +751,96 @@ sport:MembershipShape rdf:type sh:NodeShape  ;
     sh:path sport:competitionMembership ;
     sh:class sport:Competition ;
   ] .
+
+sport:NewsCodesMediaTopicShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/mediatopic/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportActionClassShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/spactionclass/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportCompetitionFormatShape
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/sptournamentform/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportCompetitionPhaseTypeShape
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/sptournamentphase/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportCompetitionScopeShape
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/spcompetitionscope/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportConceptShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/spct/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportEventOutcomeShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/speventoutcome/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportEventOutcomeTypeShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/speventoutcometype/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportPlayerStatusShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/spplayerstatus/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportPositionShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:in (
+            <http://cv.iptc.org/newscodes/sphorposition/>
+            <http://cv.iptc.org/newscodes/spichposition/>
+            <http://cv.iptc.org/newscodes/spsocposition/>
+            <http://cv.iptc.org/newscodes/spsocascpos/>
+            <http://cv.iptc.org/newscodes/vendoffpos/>
+        ) ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportResultEffectShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/spresulteffect/> ;
+        sh:maxCount 1 ;
+    ] .
+
+sport:NewsCodesSportScoreUnitsShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/spscoreunits/> ;
+        sh:maxCount 1 ;
+    ] .
 
 sport:OfficialShape rdf:type sh:NodeShape  ;
   a sh:NodeShape ;
@@ -839,9 +859,7 @@ sport:OfficialParticipationShape rdf:type sh:NodeShape  ;
   ] ;
   sh:property [
     sh:path sport:positionEvent ;
-    sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|vendoffpos)/" ;
+    sh:node sport:NewsCodesSportPositionShape
   ] .
 
 sport:ParticipatableThingShape
@@ -852,7 +870,7 @@ sport:ParticipatableThingShape
     sh:path sport:sport ;
     sh:class skos:Concept ;
     # sh:minCount 1 ; # removed for now because it breaks most of our examples!
-    sh:node sport:MediaTopicShape ;
+    sh:node sport:NewsCodesMediaTopicShape ;
   ] ;
   sh:property [
     sh:path sport:parent ;
@@ -865,30 +883,17 @@ sport:ParticipationShape
   sh:property [
     sh:path sport:eventOutcome ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
-    sh:flags   "i"                                               # Ignore case
-  ] ;
-  sh:property [
-    sh:path spstat:eventOutcome ;
-    sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportEventOutcomeShape
   ] ;
   sh:property [
     sh:path sport:eventOutcomeType ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcometype/" ;
-    sh:flags   "i"  # Ignore case
+    sh:node sport:NewsCodesSportEventOutcomeTypeShape
   ] ;
   sh:property [
     sh:path sport:positionEvent ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|vendoffpos)/" ;
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportPositionShape
   ] ;
   #sh:property [
   #  sh:path sport:participationBy ;
@@ -909,9 +914,7 @@ sport:ParticipationShape
   sh:property [
     sh:path sport:scoreUnits ;
     sh:class skos:Concept ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/spscoreunits/" ;  # term is from CV
-    sh:flags   "i"                                              # Ignore case
+    sh:node sport:NewsCodesSportScoreUnitsShape
   ] .
  
 sport:ParticipationSplitShape rdf:type sh:NodeShape  ;
@@ -922,9 +925,7 @@ sport:ParticipationSplitShape rdf:type sh:NodeShape  ;
   # properties defined on participationSplit
   sh:property [
     sh:path sport:participationSplitType ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/spcompetitionscope/" ;
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportCompetitionScopeShape
   ] ;
   # core statistics properties
   sh:property [
@@ -962,13 +963,6 @@ sport:SiteShape rdf:type sh:NodeShape  ;
   sh:closed true;
   sh:ignoredProperties ( rdf:type rdfs:label ) .
 
-sport:SportConceptShape rdf:type sh:NodeShape;
-    sh:property [
-        sh:path skos:inScheme ;
-        sh:hasValue <http://cv.iptc.org/newscodes/spct/> ;
-        sh:maxCount 1 ;
-    ] .
-
 sport:TeamShape rdf:type sh:NodeShape  ;
   a sh:NodeShape ;
   sh:targetClass sport:Team ;
@@ -997,18 +991,9 @@ sport:TeamParticipationShape rdf:type sh:NodeShape  ;
     sh:path sport:alignment ;
     sh:datatype xsd:string ;
   ] ;
-  # TODO decide whether we want sport:eventOutcome or spstat:eventOutcome
   sh:property [
     sh:path sport:eventOutcome ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
-    sh:flags   "i"                                               # Ignore case
-  ] ;
-  sh:property [
-    sh:path spstat:eventOutcome ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportEventOutcomeShape
   ] ;
   sh:property [
     sh:path sport:participationBy ;
@@ -1024,9 +1009,7 @@ sport:TeamParticipationShape rdf:type sh:NodeShape  ;
   ] ;
   sh:property [
     sh:path spstat:resultEffect ;
-    # TODO
-    sh:pattern "^http://cv.iptc.org/newscodes/spresulteffect/" ;
-    sh:flags   "i"                                               # Ignore case
+    sh:node sport:NewsCodesSportResultEffectShape
    ] ;
   sh:property [
     sh:path spstat:resultEffectTarget ;
@@ -1057,11 +1040,6 @@ sport:TeamParticipationShape rdf:type sh:NodeShape  ;
   ] ;
   sh:property [
     sh:path spstat:pointsScoredFor ;
-    sh:datatype xsd:string ;
-  ] ;
-  # TODO should be sport:score, still some instances of spstat:score
-  sh:property [
-    sh:path spstat:score ;
     sh:datatype xsd:string ;
   ] ;
   sh:property [
@@ -1101,7 +1079,7 @@ sport:TeamParticipationShape rdf:type sh:NodeShape  ;
     sh:path spsocstat:cornerKicks ;
     sh:datatype xsd:string ;
   ] ;
-  # TODO remove typo (from SportsML)
+  # TODO remove typo (inherited from SportsML)
   sh:property [
     sh:path spsocstat:foulsCommited ;
     sh:datatype xsd:string ;

--- a/ontologies/iptc-sport-shacl.ttl
+++ b/ontologies/iptc-sport-shacl.ttl
@@ -32,6 +32,7 @@ sport:ActionShape
   ] ;
   sh:property [
     sh:path sport:actionType ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/sp" ;
     sh:nodeKind sh:IRI ;
     sh:flags   "i"  # Ignore case
@@ -47,6 +48,7 @@ sport:ActionShape
   sh:property [
     sh:path sport:class ;
     sh:nodeKind sh:IRI ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/spactionclass/" ;
     sh:flags   "i"  # Ignore case
   ] ;
@@ -237,14 +239,14 @@ sport:CompetitionShape
   sh:ignoredProperties ( rdf:type rdfs:label ) ;
   sh:property [
     sh:path sport:sport ;
-    sh:pattern "^http://cv.iptc.org/newscodes/mediatopic/" ;
-    sh:flags   "i"  # Ignore case
+    sh:class skos:Concept ;
+    # sh:minCount 1 ; # removed for now because it breaks most of our examples!
+    sh:node sport:MediaTopicShape ;
   ] ;
   sh:property [
     sh:path sport:competitionType ;
     sh:class skos:Concept ;
-    sh:pattern "^http://cv.iptc.org/newscodes/spct/" ;
-    sh:flags   "i"  # Ignore case
+    sh:node sport:SportConceptShape
   ] ;
   sh:property [
     sh:path sport:parent ;
@@ -275,8 +277,8 @@ sport:CompetitionPhaseShape
   sh:property [
     sh:path sport:sport ;
     sh:class skos:Concept ;
-    sh:pattern "^http://cv.iptc.org/newscodes/mediatopic/" ;
-    sh:flags   "i"  # Ignore case
+    # sh:minCount 1 ; # removed for now because it breaks most of our examples!
+    sh:node sport:MediaTopicShape ;
   ] ;
   sh:property [
     sh:path sport:participation ;
@@ -285,6 +287,7 @@ sport:CompetitionPhaseShape
   sh:property [
     sh:path sport:competitionFormat ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/sptournamentform/" ;
     sh:flags   "i"  # Ignore case
   ] ;
@@ -295,6 +298,7 @@ sport:CompetitionPhaseShape
   sh:property [
     sh:path sport:competitionPhaseType ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/sptournamentphase/" ;
     sh:flags   "i"  # Ignore case
   ] ;
@@ -312,24 +316,28 @@ sport:CompetitorParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:eventOutcome ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
   sh:property [
     sh:path spstat:eventOutcome ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
   sh:property [
     sh:path sport:eventOutcomeType ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcometype/" ;
     sh:flags   "i"  # Ignore case
   ] ;
   sh:property [
     sh:path sport:positionEvent ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|vendoffpos)/" ;
     sh:flags   "i"                                               # Ignore case
   ] ;
@@ -356,6 +364,7 @@ sport:CompetitorParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:scoreUnits ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/spscoreunits/" ;  # term is from CV
     sh:flags   "i"                                              # Ignore case
   ] .
@@ -404,18 +413,20 @@ sport:EventShape rdf:type sh:NodeShape ;
   sh:property [
     sh:path sport:sport ;
     sh:class skos:Concept ;
-    sh:pattern "^http://cv.iptc.org/newscodes/mediatopic/" ;     # term is from CV
-    sh:flags   "i"                                               # Ignore case
+    # sh:minCount 1 ; # removed for now because it breaks most of our examples!
+    sh:node sport:MediaTopicShape ;
   ] ;
   sh:property [
     sh:path sport:eventOutcomeType ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcometype/" ; # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
   sh:property [
     sh:path sport:eventStatus ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventstatus/" ;  # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
@@ -446,10 +457,8 @@ sport:IndividualMembershipShape
   sh:property [
     sh:path sport:positionRegular ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|sphorposition|spichposition)/" ;
-    # TODO we really should check for individual vocabularies...
-    # but some example data fails (needs to be fixed) so let's cheat for now
-    # sh:pattern "^http://cv.iptc.org/newscodes/" ;
     sh:flags   "i"                                               # Ignore case
   ] ;
   sh:property [
@@ -470,6 +479,7 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:playerStatus ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/spplayerstatus/" ;
     sh:flags   "i"  # Ignore case
   ] ;
@@ -477,6 +487,7 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:playerStatus ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/spplayerstatus/" ;
     sh:flags   "i"  # Ignore case
   ] ;
@@ -485,24 +496,28 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:eventOutcome ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
   sh:property [
     sh:path spstat:eventOutcome ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
   sh:property [
     sh:path sport:eventOutcomeType ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcometype/" ;
     sh:flags   "i"  # Ignore case
   ] ;
   sh:property [
     sh:path sport:positionEvent ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|vendoffpos)/" ;
     sh:flags   "i"                                               # Ignore case
   ] ;
@@ -529,6 +544,7 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:scoreUnits ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/spscoreunits/" ;  # term is from CV
     sh:flags   "i"                                              # Ignore case
   ] ;
@@ -544,6 +560,7 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path spstat:resultEffect ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/spresulteffect/" ;
     sh:flags   "i"                                               # Ignore case
    ] ;
@@ -755,6 +772,13 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
     sh:datatype xsd:string ;
   ] .
 
+sport:MediaTopicShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/mediatopic/> ;
+        sh:maxCount 1 ;
+    ] .
+
 sport:MembershipShape rdf:type sh:NodeShape  ;
   a sh:NodeShape ;
   sh:targetClass sport:Membership ;
@@ -778,6 +802,7 @@ sport:OfficialParticipationShape rdf:type sh:NodeShape  ;
   sh:property [
     sh:path sport:positionEvent ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|vendoffpos)/" ;
   ] .
 
@@ -788,8 +813,8 @@ sport:ParticipatableThingShape
   sh:property [
     sh:path sport:sport ;
     sh:class skos:Concept ;
-    sh:pattern "^http://cv.iptc.org/newscodes/mediatopic/" ;
-    sh:flags   "i"  # Ignore case
+    # sh:minCount 1 ; # removed for now because it breaks most of our examples!
+    sh:node sport:MediaTopicShape ;
   ] ;
   sh:property [
     sh:path sport:parent ;
@@ -802,24 +827,28 @@ sport:ParticipationShape
   sh:property [
     sh:path sport:eventOutcome ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
   sh:property [
     sh:path spstat:eventOutcome ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
   sh:property [
     sh:path sport:eventOutcomeType ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcometype/" ;
     sh:flags   "i"  # Ignore case
   ] ;
   sh:property [
     sh:path sport:positionEvent ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/(spsocposition|spsocascpos|vendoffpos)/" ;
     sh:flags   "i"                                               # Ignore case
   ] ;
@@ -842,6 +871,7 @@ sport:ParticipationShape
   sh:property [
     sh:path sport:scoreUnits ;
     sh:class skos:Concept ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/spscoreunits/" ;  # term is from CV
     sh:flags   "i"                                              # Ignore case
   ] .
@@ -854,6 +884,7 @@ sport:ParticipationSplitShape rdf:type sh:NodeShape  ;
   # properties defined on participationSplit
   sh:property [
     sh:path sport:participationSplitType ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/spcompetitionscope/" ;
     sh:flags   "i"                                               # Ignore case
   ] ;
@@ -893,6 +924,13 @@ sport:SiteShape rdf:type sh:NodeShape  ;
   sh:closed true;
   sh:ignoredProperties ( rdf:type rdfs:label ) .
 
+sport:SportConceptShape rdf:type sh:NodeShape;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://cv.iptc.org/newscodes/spct/> ;
+        sh:maxCount 1 ;
+    ] .
+
 sport:TeamShape rdf:type sh:NodeShape  ;
   a sh:NodeShape ;
   sh:targetClass sport:Team ;
@@ -911,11 +949,13 @@ sport:TeamParticipationShape rdf:type sh:NodeShape  ;
   # TODO decide whether we want sport:eventOutcome or spstat:eventOutcome
   sh:property [
     sh:path sport:eventOutcome ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
   sh:property [
     sh:path spstat:eventOutcome ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/speventoutcome/" ; # term is from CV
     sh:flags   "i"                                               # Ignore case
   ] ;
@@ -933,6 +973,7 @@ sport:TeamParticipationShape rdf:type sh:NodeShape  ;
   ] ;
   sh:property [
     sh:path spstat:resultEffect ;
+    # TODO
     sh:pattern "^http://cv.iptc.org/newscodes/spresulteffect/" ;
     sh:flags   "i"                                               # Ignore case
    ] ;

--- a/tools/prefixes.ttl
+++ b/tools/prefixes.ttl
@@ -7,13 +7,14 @@
 @prefix spespstat: <https://sportschema.org/ontologies/esports/> .
 @prefix spsocstat: <https://sportschema.org/ontologies/soccer/> .
 # Controlled vocabularies
+@prefix medtop: <http://cv.iptc.org/newscodes/mediatopic/> .
+@prefix spcompetitionscope: <http://cv.iptc.org/newscodes/spcompetitionscope/> .
 @prefix spct: <http://cv.iptc.org/newscodes/spct/> .
 @prefix spplayerstatus: <http://cv.iptc.org/newscodes/spplayerstatus/> .
 @prefix spsocactiontype: <http://cv.iptc.org/newscodes/spsocaction/> .
 @prefix speventoutcome: <http://cv.iptc.org/newscodes/speventoutcome/> .
 @prefix speventoutcometype: <http://cv.iptc.org/newscodes/speventoutcometype/> .
-@prefix spcompetitionscope: <http://cv.iptc.org/newscodes/spcompetitionscope/> .
+@prefix sphorposition: <http://cv.iptc.org/newscodes/sphorposition/> .
 @prefix spsocrole: <http://cv.iptc.org/newscodes/spsocrole/> .
 @prefix spesaction: <http://cv.iptc.org/newscodes/spesaction/> .
-@prefix medtop: <http://cv.iptc.org/newscodes/mediatopic/> .
 

--- a/vocabularies/spactionclass.ttl
+++ b/vocabularies/spactionclass.ttl
@@ -1,0 +1,43 @@
+@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix skos:	<http://www.w3.org/2004/02/skos/core#>.
+@prefix owl:	<http://www.w3.org/2002/07/owl#>.
+@prefix spactionclass:	<http://cv.iptc.org/newscodes/spactionclass/>
+
+<http://cv.iptc.org/newscodes/spactionclass/> 
+	rdf:type skos:ConceptScheme;
+	skos:HasTopConcept		spactionclass:timeout;
+	skos:HasTopConcept		spactionclass:play;
+	skos:HasTopConcept		spactionclass:substitution;
+	skos:HasTopConcept		spactionclass:score;
+	skos:HasTopConcept		spactionclass:penalty;
+	skos:HasTopConcept		spactionclass:official-procedure.
+
+spactionclass:timeout
+	rdf:type skos:Concept;
+	skos:prefLabel	"timeout"@en-GB;
+	skos:inScheme <http://cv.iptc.org/newscodes/spactionclass/>.
+
+spactionclass:play
+	rdf:type skos:Concept;
+	skos:prefLabel	"play"@en-GB;
+	skos:inScheme <http://cv.iptc.org/newscodes/spactionclass/>.
+
+spactionclass:substitution
+	rdf:type skos:Concept;
+	skos:prefLabel	"substitution"@en-GB;
+	skos:inScheme <http://cv.iptc.org/newscodes/spactionclass/>.
+
+spactionclass:score
+	rdf:type skos:Concept;
+	skos:prefLabel	"score"@en-GB;
+	skos:inScheme <http://cv.iptc.org/newscodes/spactionclass/>.
+
+spactionclass:penalty
+	rdf:type skos:Concept;
+	skos:prefLabel	"penalty"@en-GB;
+	skos:inScheme <http://cv.iptc.org/newscodes/spactionclass/>.
+
+spactionclass:official-procedure
+	rdf:type skos:Concept;
+	skos:prefLabel	"official-procedure"@en-GB;
+	skos:inScheme <http://cv.iptc.org/newscodes/spactionclass/>.

--- a/vocabularies/sphorposition.ttl
+++ b/vocabularies/sphorposition.ttl
@@ -1,20 +1,34 @@
-@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix skos:	<http://www.w3.org/2004/02/skos/core#>.
-@prefix owl:	<http://www.w3.org/2002/07/owl#>.
-@prefix sphorpos:	<http://cv.iptc.org/newscodes/sphorposition/>
 
-<http://cv.iptc.org/newscodes/sphorpos/> 
-	rdf:type skos:ConceptScheme;
-	skos:hasTopConcept		sphorpos:horse ;
-	skos:hasTopConcept		sphorpos:jockey .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos:   <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sphorposition: <http://cv.iptc.org/newscodes/sphorposition/>
 
-sphorpos:horse
-	rdf:type skos:Concept;
-	skos:prefLabel	"horse"@en-GB;
-	skos:inScheme <http://cv.iptc.org/newscodes/sphorpos/>.
+<http://cv.iptc.org/newscodes/sphorposition/> 
+	rdf:type skos:ConceptScheme ; 
+  dct:rightsHolder "IPTC, International Press Telecommunications Council - https://iptc.org" ;
+  dct:dateSubmitted "2024-06-30T12:00:00+00:00"^^xsd:dateTime ;
+  skos:prefLabel "Horse Racing Positions"@en-GB ;
+  skos:definition "Positions in horse racing"@en-GB ;
+	skos:hasTopConcept		sphorposition:horse ;
+	skos:hasTopConcept		sphorposition:jockey ;
+	skos:hasTopConcept		sphorposition:trainer .
 
-sphorpos:jockey
-	rdf:type skos:Concept;
-	skos:prefLabel	"jockey"@en-GB;
-	skos:inScheme <http://cv.iptc.org/newscodes/sphorpos/>.
+sphorposition:horse
+	rdf:type skos:Concept ;
+	skos:prefLabel	"horse"@en-GB ;
+	skos:inScheme <http://cv.iptc.org/newscodes/sphorposition/>  ;
+	dct:created "2024-02-13T12:00:00+00:00"^^xsd:dateTime .
 
+sphorposition:jockey
+	rdf:type skos:Concept ;
+	skos:prefLabel	"jockey"@en-GB ;
+	skos:inScheme <http://cv.iptc.org/newscodes/sphorposition/>  ;
+	dct:created "2024-02-13T12:00:00+00:00"^^xsd:dateTime .
+
+sphorposition:trainer
+	rdf:type skos:Concept ;
+	skos:prefLabel	"trainer"@en-GB ;
+	skos:inScheme <http://cv.iptc.org/newscodes/sphorposition/>  ;
+	dct:created "2024-06-28T12:00:00+00:00"^^xsd:dateTime .


### PR DESCRIPTION
Added SKOS validation for Media Topic as suggested by @riannella. Will fix #197 .

Now we have to do the same for all other vocabularies.