### PR TITLE
Add teamParticipation property linking IndividualParticipation to TeamParticipation

### DIFF
--- a/ontologies/iptc-sport-ontology.ttl
+++ b/ontologies/iptc-sport-ontology.ttl
@@ -564,6 +564,13 @@ sport:startDate rdf:type owl:DatatypeProperty ;
     rdfs:range xsd:date ;
     rdfs:isDefinedBy <https://sportschema.org/ontologies/main/> .
 
+sport:teamParticipation rdf:type owl:ObjectProperty ;
+    rdfs:label "team participation"@en ;
+    rdfs:comment "Link to the team of which this individual is a member, with respect to this Participation"@en;
+    rdfs:domain sport:IndividualParticipation ;
+    rdfs:range sport:TeamParticipation ;
+    rdfs:isDefinedBy <https://sportschema.org/ontologies/main/> .
+
 sport:uniformNumber rdf:type owl:DatatypeProperty ;
     rdfs:label "uniform number"@en ;
     rdfs:comment "The number usually worn on a player's uniform (jersey etc.) Note that the value may be a string such as 'unknown'."@en ;

--- a/ontologies/iptc-sport-shacl.ttl
+++ b/ontologies/iptc-sport-shacl.ttl
@@ -532,6 +532,10 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
     sh:pattern "^http://cv.iptc.org/newscodes/spscoreunits/" ;  # term is from CV
     sh:flags   "i"                                              # Ignore case
   ] ;
+  sh:property [
+    sh:path sport:teamParticipation ;
+    sh:class sport:TeamParticipation ;
+  ] ;
   # properties defined on CompetitorParticipation by core statistics ontology
   sh:property [
     sh:path spstat:eventsStarted ;
@@ -758,7 +762,15 @@ sport:IndividualParticipationShape rdf:type sh:NodeShape  ;
 sport:MembershipShape rdf:type sh:NodeShape  ;
   a sh:NodeShape ;
   sh:targetClass sport:Membership ;
-  sh:ignoredProperties ( rdf:type rdfs:label ) .
+  sh:ignoredProperties ( rdf:type rdfs:label ) ;
+  sh:property [
+    sh:path sport:startDate ;
+    sh:datatype xsd:date ;
+  ] ;
+  sh:property [
+    sh:path sport:endtDate ;
+    sh:datatype xsd:date ;
+  ] .
 
 sport:OfficialShape rdf:type sh:NodeShape  ;
   a sh:NodeShape ;


### PR DESCRIPTION
Add teamParticipation property linking IndividualParticipation to TeamParticipation.

Allows us to track which team a player is playing for without having to guess based on membership dates. Fixes #191.